### PR TITLE
go: Make package usable with go get

### DIFF
--- a/go/vmnet_broker/vmnet-broker.h
+++ b/go/vmnet_broker/vmnet-broker.h
@@ -1,1 +1,0 @@
-../../vmnet-broker.h

--- a/go/vmnet_broker/vmnet_broker.c
+++ b/go/vmnet_broker/vmnet_broker.c
@@ -1,0 +1,1 @@
+#include "../../client.c"

--- a/go/vmnet_broker/vmnet_broker.go
+++ b/go/vmnet_broker/vmnet_broker.go
@@ -1,10 +1,11 @@
+//go:build darwin
+
 package vmnet_broker
 
 /*
-#cgo LDFLAGS: -L${SRCDIR}/../.. -lvmnet-broker
+#cgo CFLAGS: -I${SRCDIR}/../.. -Wall -O2
 #include "vmnet-broker.h"
 #include <stdlib.h>
-#include <xpc/xpc.h>
 */
 import "C"
 import (


### PR DESCRIPTION
Compile from source using CGO:
- Add go/vmnet_broker/vmnet_broker.c including ../../client.c
- Add header search path (${SRCROT}/../..) for vmnet-broker.h
- Add -O2 to enable optimization
- Add -Wall to enable warnings
- Add //go:build darwin build tag to allow build only on darwin
- Remove unneeded LDFLAGS, we don't link with the static library, and we
- Remove unneeded <xpc/xpc.h> include - vmnet-broker.h includes it don't need to link with vment.

Tested locally by creating a new project importing vmnet_broker and using replace to consume the checkout from another directory.

Fixes #27 