### PR TITLE
ci: Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,61 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go/go.mod
+          cache: false
+
+      - name: Cache Go build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-build-${{ hashFiles('go/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
 
       - name: Install clang-format
         run: brew install clang-format
 
+      - name: Cache Swift packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            swift/.build
+            swift/Package.resolved
+          key: ${{ runner.os }}-swift-${{ hashFiles('swift/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-
+
+      - name: Get vz branch commit hash
+        id: vz-commit
+        run: |
+          COMMIT=$(git ls-remote https://github.com/norio-nomura/vz feat-add-vmnet-network-device-attachment | cut -f1)
+          echo "commit=$COMMIT" >> $GITHUB_OUTPUT
+          echo "vz branch commit: $COMMIT"
+
+      - name: Cache vz dependency
+        id: cache-vz
+        uses: actions/cache@v4
+        with:
+          path: ../norio-nomura/vz
+          key: ${{ runner.os }}-vz-${{ hashFiles('go/go.mod') }}-${{ steps.vz-commit.outputs.commit }}
+          restore-keys: |
+            ${{ runner.os }}-vz-
+
       - name: Setup Go test dependency
         run: |
-          git clone https://github.com/norio-nomura/vz ../norio-nomura/vz
+          if [ ! -d "../norio-nomura/vz" ]; then
+            git clone https://github.com/norio-nomura/vz ../norio-nomura/vz
+          fi
           cd ../norio-nomura/vz
-          git checkout feat-add-vmnet-network-device-attachment
+          CURRENT=$(git rev-parse HEAD 2>/dev/null || echo "")
+          EXPECTED="${{ steps.vz-commit.outputs.commit }}"
+          if [ "$CURRENT" != "$EXPECTED" ]; then
+            echo "Updating to latest commit: $EXPECTED"
+            git fetch origin
+            git checkout feat-add-vmnet-network-device-attachment
+            git reset --hard origin/feat-add-vmnet-network-device-attachment
+          fi
           make
 
       - name: Build


### PR DESCRIPTION
Add CI workflow that runs on macos-26 runner to build, install, and test the broker. This enables automated testing for contributions and helps catch regressions early.

The workflow runs automatically on:
- Pushes to main
- All pull requests
- Daily schedule (to catch issues with the upstream Go PR we depend on)
- Manual triggering via workflow_dispatch

The workflow also sets up the upstream Go dependency (norio-nomura/vz) required for Go tests by cloning and building it before running tests.

When the Go PR is merged, we can move to weekly builds to protect from external changes (e.g., runner image updates).