### PR TITLE
ci: Fix cache path warning for vz dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         id: cache-vz
         uses: actions/cache@v4
         with:
-          path: ../norio-nomura/vz
+          path: ${{ runner.workspace }}/norio-nomura/vz
           key: ${{ runner.os }}-vz-${{ hashFiles('go/go.mod') }}-${{ steps.vz-commit.outputs.commit }}
           restore-keys: |
             ${{ runner.os }}-vz-


### PR DESCRIPTION
Use absolute path with ${{ github.workspace }} instead of relative path '../norio-nomura/vz'. GitHub Actions cache doesn't support relative paths with '..'.