### PR TITLE
docs: Document vmnet-helper integration

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -5,10 +5,34 @@ SPDX-License-Identifier: Apache-2.0
 
 # Integrations
 
-> [!NOTE]
-> These integrations are not implemented yet.
+## Using with vmnet-helper
+
+On macOS 26, vmnet-helper can join a vmnet-broker network using the
+`--network` option. VMs using vmnet-helper share the same subnet as VMs
+using native vmnet, but use file-handle based packet forwarding instead
+of native vmnet performance.
+
+This is useful for VMs that don't support native vmnet (e.g. QEMU,
+libkrun) but need to communicate with VMs on the broker network.
+
+```
+vmnet-helper --network shared --fd 3
+```
+
+Or using vmnet-client:
+
+```
+vmnet-client --network shared -- vfkit --device virtio-net,fd=4 ...
+```
+
+For more info see the [vmnet-helper architecture].
+
+[vmnet-helper architecture]: https://github.com/nirs/vmnet-helper/blob/main/docs/architecture.md#native-vmnet-on-macos-26
 
 ## Using with vfkit
+
+> [!NOTE]
+> This integration is not implemented yet.
 
 To start a virtual machine using vfkit use the `vmnet` virtio-net device:
 
@@ -22,6 +46,9 @@ instances they will use the same network and can communicate.
 For more info see https://github.com/crc-org/vfkit/issues/439
 
 ## Using with Minikube
+
+> [!NOTE]
+> This integration is not implemented yet.
 
 To start a cluster with the vfkit driver using the vmnet "shared" network:
 


### PR DESCRIPTION
vmnet-helper can join a vmnet-broker network on macOS 26 using the --network option. This lets VMs that don't support native vmnet (e.g. QEMU, libkrun) share the same subnet as native vmnet VMs.

Also moved the "not implemented yet" notes from the page header to the individual vfkit and Minikube sections.

Fixes #70 